### PR TITLE
use relative URL, not absolute

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,7 +23,7 @@ export class TUtils {
 
 	static syncTranslation(OnFinished = () => { }) {
 		var locale = localStorage.getItem(TUtils.LOCALE_ID) || "en-US";
-		var url = "/agl/get_translation";
+		var url = "./agl/get_translation";
 		var request = new XMLHttpRequest();
 		request.open("post", url);
 		request.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");


### PR DESCRIPTION
see https://github.com/comfyanonymous/ComfyUI/pull/867 for explanation

tldr: this tiny change makes the extension compatible with reverse-proxy forwarding of Comfy, as done for example in StableSwarmUI

Original issue: https://github.com/Stability-AI/StableSwarmUI/issues/117