### PR TITLE
Guard array access

### DIFF
--- a/main.js
+++ b/main.js
@@ -137,7 +137,7 @@ export class TUtils {
     let class_type = node.constructor.comfyClass ? node.constructor.comfyClass : node.constructor.type;
     if (!nodesT.hasOwnProperty(class_type)) {
       for (let key of keys) {
-        if (!node.hasOwnProperty(key)) continue;
+        if (!node.hasOwnProperty(key) || !Array.isArray(node[key])) continue;
         node[key].forEach((item) => {
           if (item?.hasOwnProperty("name")) item.label = item.name;
         });


### PR DESCRIPTION
Somehow one of the field can be undefined. This PR adds the array type check so that the issue can be localized.

![image](https://github.com/user-attachments/assets/aebe5cb6-36d7-4108-a24f-b3a896f83905)

```
TypeError: Cannot read properties of undefined (reading 'forEach')
    at TUtils.applyNodeTranslation (http://127.0.0.1:8188/extensions/AIGODLIKE-ComfyUI-Translation/main.js:141:19)
    at Object.nodeCreated (http://127.0.0.1:8188/extensions/AIGODLIKE-ComfyUI-Translation/main.js:499:12)
    at http://127.0.0.1:8188/assets/index-DzdniCiz.js:86899:37
    at Array.map (<anonymous>)
    at #invokeExtensionsAsync (http://127.0.0.1:8188/assets/index-DzdniCiz.js:86896:30)
    at new ComfyNode (http://127.0.0.1:8188/assets/index-DzdniCiz.js:88205:37)
    at LiteGraphGlobal.createNode (http://127.0.0.1:8188/assets/index-DzdniCiz.js:39951:18)
    at ComfyApp.addNodeOnGraph (http://127.0.0.1:8188/assets/index-DzdniCiz.js:88903:29)
    at addNode (http://127.0.0.1:8188/assets/GraphView-DCuvfrO2.js:3255:24)
    at callWithErrorHandling (http://127.0.0.1:8188/assets/index-DzdniCiz.js:2038:19)
```