### PR TITLE
Use slot.localized_name

### DIFF
--- a/main.js
+++ b/main.js
@@ -178,7 +178,7 @@ export class TUtils {
       // console.log(slot);
       let t = TUtils.T.Nodes[this.comfyClass];
       if (t["widgets"] && slot.name in t["widgets"]) {
-        slot.label = t["widgets"][slot.name];
+        slot.localized_name = t["widgets"][slot.name];
       }
       if (onInputAdded) return res;
     };


### PR DESCRIPTION
Resolves https://github.com/Comfy-Org/ComfyUI_frontend/issues/2732

Use slot.localized_name to avoid persist translated name to workflow. Ref: https://github.com/Comfy-Org/litegraph.js/pull/376 